### PR TITLE
Cargo.lock: add source & checksum for `tar` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,6 +1186,8 @@ dependencies = [
 [[package]]
 name = "tar"
 version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
 dependencies = [
  "filetime",
  "libc",


### PR DESCRIPTION
For some reason the `source` and `checksum` info are missing for the `tar` crate and so this PR adds them.