### PR TITLE
Implement TarOperation and TarParam foundations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,24 +614,24 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jiff"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+checksum = "49cce2b81f2098e7e3efc35bc2e0a6b7abec9d34128283d7a26fa8f32a6dbb35"
 dependencies = [
  "jiff-static",
  "jiff-tzdb-platform",
  "log",
  "portable-atomic",
  "portable-atomic-util",
- "serde",
- "windows-sys 0.59.0",
+ "serde_core",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+checksum = "980af8b43c3ad5d8d349ace167ec8170839f753a42d233ba19e08afe1850fa69"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1380,6 +1380,7 @@ name = "uu_tar"
 version = "0.0.1"
 dependencies = [
  "clap",
+ "jiff",
  "regex",
  "tar",
  "uucore",
@@ -1575,20 +1576,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1602,42 +1594,20 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1647,21 +1617,9 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1671,21 +1629,9 @@ checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1695,33 +1641,15 @@ checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1335,6 +1335,7 @@ name = "uu_tar"
 version = "0.0.1"
 dependencies = [
  "clap",
+ "jiff",
  "regex",
  "tar",
  "uucore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ tempfile = "3.10.1"
 textwrap = { version = "0.16.1", features = ["terminal_size"] }
 xattr = "1.3.1"
 zip = "7.0"
+jiff = "0.2.16"
 
 [dependencies]
 clap = { workspace = true }
@@ -64,6 +65,8 @@ uucore = { workspace = true }
 uuhelp_parser = { workspace = true, optional = true }
 zip = { workspace = true, optional = true }
 tar = { optional = true, version = "0.0.1", package = "uu_tar", path = "src/uu/tar" }
+jiff = { workspace = true }
+
 
 [dev-dependencies]
 chrono = { workspace = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ tar = "0.4"
 tempfile = "3.10.1"
 textwrap = { version = "0.16.1", features = ["terminal_size"] }
 xattr = "1.3.1"
-zip = "6.0"
+zip = "7.0"
 jiff = "0.2.16"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,6 @@ uutests = { workspace = true }
 uucore = { workspace = true }
 uuhelp_parser = { workspace = true, optional = true }
 zip = { workspace = true, optional = true }
-
 tar = { optional = true, version = "0.0.1", package = "uu_tar", path = "src/uu/tar" }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ tempfile = "3.10.1"
 textwrap = { version = "0.16.1", features = ["terminal_size"] }
 xattr = "1.3.1"
 zip = "6.0"
+jiff = "0.2.16"
 
 [dependencies]
 clap = { workspace = true }
@@ -64,6 +65,8 @@ uucore = { workspace = true }
 uuhelp_parser = { workspace = true, optional = true }
 zip = { workspace = true, optional = true }
 tar = { optional = true, version = "0.0.1", package = "uu_tar", path = "src/uu/tar" }
+jiff = { workspace = true }
+
 
 [dev-dependencies]
 chrono = { workspace = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ tempfile = "3.10.1"
 textwrap = { version = "0.16.1", features = ["terminal_size"] }
 xattr = "1.3.1"
 zip = "7.0"
+jiff = "0.2.16"
 
 [dependencies]
 clap = { workspace = true }
@@ -63,8 +64,9 @@ uutests = { workspace = true }
 uucore = { workspace = true }
 uuhelp_parser = { workspace = true, optional = true }
 zip = { workspace = true, optional = true }
-
 tar = { optional = true, version = "0.0.1", package = "uu_tar", path = "src/uu/tar" }
+jiff = { workspace = true }
+
 
 [dev-dependencies]
 chrono = { workspace = true }

--- a/src/uu/tar/Cargo.toml
+++ b/src/uu/tar/Cargo.toml
@@ -17,6 +17,7 @@ uucore = { workspace = true }
 clap = { workspace = true }
 regex = { workspace = true }
 tar = { workspace = true }
+jiff = { workspace = true }
 
 [lib]
 path = "src/tar.rs"

--- a/src/uu/tar/Cargo.toml
+++ b/src/uu/tar/Cargo.toml
@@ -17,6 +17,7 @@ uucore = { workspace = true }
 clap = { workspace = true }
 regex = { workspace = true }
 tar = { workspace = true }
+jiff = "0.2.16"
 
 [lib]
 path = "src/tar.rs"

--- a/src/uu/tar/Cargo.toml
+++ b/src/uu/tar/Cargo.toml
@@ -17,7 +17,7 @@ uucore = { workspace = true }
 clap = { workspace = true }
 regex = { workspace = true }
 tar = { workspace = true }
-jiff = "0.2.16"
+jiff = { workspace = true }
 
 [lib]
 path = "src/tar.rs"

--- a/src/uu/tar/src/operations/create.rs
+++ b/src/uu/tar/src/operations/create.rs
@@ -4,10 +4,28 @@
 // file that was distributed with this source code.
 
 use crate::errors::TarError;
+use crate::operations::TarOperation;
+use crate::options::{TarOption, TarParams};
 use std::fs::File;
 use std::path::Path;
+use std::path::PathBuf;
 use tar::Builder;
 use uucore::error::UResult;
+
+pub struct Create;
+
+impl TarOperation for Create {
+    fn exec(&self, options: &TarParams) -> UResult<()> {
+        create_archive(
+            options.archive(),
+            options.files().as_slice(),
+            options
+                .options()
+                .iter()
+                .any(|x| matches!(x, TarOption::Verbose)),
+        )
+    }
+}
 
 /// Create a tar archive from the specified files
 ///
@@ -23,7 +41,7 @@ use uucore::error::UResult;
 /// - The archive file cannot be created
 /// - Any input file cannot be read
 /// - Files cannot be added due to I/O or permission errors
-pub fn create_archive(archive_path: &Path, files: &[&Path], verbose: bool) -> UResult<()> {
+pub fn create_archive(archive_path: &Path, files: &[PathBuf], verbose: bool) -> UResult<()> {
     // Create the output file
     let file = File::create(archive_path).map_err(|e| {
         TarError::TarOperationError(format!(
@@ -41,7 +59,7 @@ pub fn create_archive(archive_path: &Path, files: &[&Path], verbose: bool) -> UR
     }
 
     // Add each file or directory to the archive
-    for &path in files {
+    for path in files {
         if verbose {
             println!("{}", path.display());
         }

--- a/src/uu/tar/src/operations/create.rs
+++ b/src/uu/tar/src/operations/create.rs
@@ -6,10 +6,9 @@
 use crate::errors::TarError;
 use crate::operations::TarOperation;
 use crate::options::{TarOption, TarParams};
-use std::fs::File;
-use std::path::Path;
-use std::path::PathBuf;
 use std::collections::VecDeque;
+use std::fs::{self, File};
+use std::path::{self, Path, PathBuf};
 use tar::Builder;
 use uucore::error::UResult;
 
@@ -60,7 +59,7 @@ pub fn create_archive(archive_path: &Path, files: &[PathBuf], verbose: bool) -> 
     }
 
     // Add each file or directory to the archive
-    for &path in files {
+    for path in files {
         // Check if path exists
         if !path.exists() {
             return Err(TarError::FileNotFound(path.display().to_string()).into());

--- a/src/uu/tar/src/operations/extract.rs
+++ b/src/uu/tar/src/operations/extract.rs
@@ -4,10 +4,26 @@
 // file that was distributed with this source code.
 
 use crate::errors::TarError;
+use crate::operations::operation::TarOperation;
+use crate::options::options::{TarOption, TarParams};
 use std::fs::File;
 use std::path::Path;
 use tar::Archive;
 use uucore::error::UResult;
+
+pub(crate) struct Extract;
+
+impl TarOperation for Extract {
+    fn exec(&self, options: &TarParams) -> UResult<()> {
+        extract_archive(
+            options.archive(),
+            options
+                .options()
+                .iter()
+                .any(|x| matches!(x, TarOption::Verbose)),
+        )
+    }
+}
 
 /// Extract files from a tar archive
 ///

--- a/src/uu/tar/src/operations/mod.rs
+++ b/src/uu/tar/src/operations/mod.rs
@@ -5,3 +5,9 @@
 
 pub mod create;
 pub mod extract;
+pub mod operation;
+
+pub(crate) use self::create::Create;
+pub(crate) use self::extract::Extract;
+pub(crate) use self::operation::OperationKind;
+pub use self::operation::TarOperation;

--- a/src/uu/tar/src/operations/operation.rs
+++ b/src/uu/tar/src/operations/operation.rs
@@ -1,0 +1,58 @@
+use crate::errors::TarError;
+use crate::operations::Create;
+use crate::operations::Extract;
+use crate::options::TarParams;
+use uucore::error::UResult;
+
+/// The [`OperationKind`] Enum representation of Acdtrux arguments which is
+/// later leveraged as selector for enum dispatch by the [`TarOperation`]
+/// trait
+pub enum OperationKind {
+    Concatenate,
+    Create,
+    Diff,
+    List,
+    Append,
+    Update,
+    Extract,
+}
+
+impl TryFrom<&str> for OperationKind {
+    type Error = TarError;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "concate" => Ok(Self::Concatenate),
+            "create" => Ok(Self::Create),
+            "diff" => Ok(Self::Diff),
+            "list" => Ok(Self::List),
+            "append" => Ok(Self::Append),
+            "update" => Ok(Self::Update),
+            "extract" => Ok(Self::Extract),
+            _ => Err(TarError::TarOperationError(format!(
+                "Invalid operation selected: {}",
+                value
+            ))),
+        }
+    }
+}
+
+impl TarOperation for OperationKind {
+    fn exec(&self, options: &TarParams) -> UResult<()> {
+        match self {
+            Self::List => unimplemented!(),
+            Self::Create => Create.exec(options),
+            Self::Diff => unimplemented!(),
+            Self::Append => unimplemented!(),
+            Self::Update => unimplemented!(),
+            Self::Extract => Extract.exec(options),
+            Self::Concatenate => unimplemented!(),
+        }
+    }
+}
+
+/// [`TarOperation`] allows enum dispatch by enforcing the impl of the
+/// trait to create the functionality to perform the operation requested via
+/// the command line arg for this execution of tar
+pub trait TarOperation {
+    fn exec(&self, options: &TarParams) -> UResult<()>;
+}

--- a/src/uu/tar/src/options/mod.rs
+++ b/src/uu/tar/src/options/mod.rs
@@ -1,0 +1,6 @@
+// re-exported to remove the redundant level of inception in
+// the module tree
+#[allow(clippy::module_inception)]
+pub mod options;
+pub use crate::options::options::TarOption;
+pub use crate::options::options::TarParams;

--- a/src/uu/tar/src/options/options.rs
+++ b/src/uu/tar/src/options/options.rs
@@ -15,6 +15,16 @@ pub struct TarParams {
     options: Vec<TarOption>,
 }
 
+impl Default for TarParams {
+    fn default() -> TarParams {
+        Self {
+            archive: PathBuf::default(),
+            options: Vec::new(),
+            files: Vec::new(),
+        }
+    }
+}
+
 impl From<&ArgMatches> for TarParams {
     fn from(matches: &ArgMatches) -> TarParams {
         let mut ops = Self::default();

--- a/src/uu/tar/src/options/options.rs
+++ b/src/uu/tar/src/options/options.rs
@@ -7,7 +7,6 @@ use uucore::error::UResult;
 /// [`TarParams`] Holds common information that is parsed from
 /// command line arguments. That changes the current execution of
 /// tar.
-#[allow(dead_code)]
 #[derive(Default)]
 pub struct TarParams {
     archive: PathBuf,
@@ -49,27 +48,23 @@ impl TarParams {
         } else if matches.get_flag("extract") {
             Ok((OperationKind::Extract, Self::from(matches)))
         } else {
-            // TODO: update messaging
-            Err(Box::new(TarError::TarOperationError(
-                "Error processing: Operations".to_string(),
-            )))
+            Err(Box::new(TarError::TarOperationError(format!(
+                "Error processing: Unknown or Unimplmented Parameters: {:?}",
+                matches
+                    .ids()
+                    .map(|i| i.to_string())
+                    .collect::<Vec<String>>()
+            ))))
         }
     }
 }
 
-#[allow(dead_code)]
 impl TarParams {
     pub fn files(&self) -> &Vec<PathBuf> {
         &self.files
     }
-    pub fn files_mut(&mut self) -> &mut Vec<PathBuf> {
-        &mut self.files
-    }
     pub fn archive(&self) -> &PathBuf {
         &self.archive
-    }
-    pub fn archive_mut(&mut self) -> &mut PathBuf {
-        &mut self.archive
     }
     pub fn options(&self) -> &Vec<TarOption> {
         &self.options
@@ -81,12 +76,6 @@ impl TarParams {
 
 /// [`TarOption`] Enum of avaliable tar options for later use
 /// by [`TarOperation`] impls, eg. List, Create, Delete
-#[allow(dead_code)]
 pub enum TarOption {
-    AbsoluteNames,
-    ACLs,
-    AfterDate,
-    Anchored,
-    AtimePreserve { arg: String },
     Verbose,
 }

--- a/src/uu/tar/src/options/options.rs
+++ b/src/uu/tar/src/options/options.rs
@@ -14,9 +14,6 @@ pub struct TarParams {
     options: Vec<TarOption>,
 }
 
-/// [`Default`] Produces safe default values for [`TarParams`] and [`TarOption`]s
-/// for this tar execution. Block-Size of 512 bytes, Empty vec's of
-/// options and file names.
 impl Default for TarParams {
     fn default() -> TarParams {
         Self {
@@ -27,35 +24,26 @@ impl Default for TarParams {
     }
 }
 
-// NOTE: I feel like this is just reimplmenting the parsing functionality of
-// clap
 impl From<&ArgMatches> for TarParams {
     fn from(matches: &ArgMatches) -> TarParams {
-        let mut fp = vec![];
+
         let mut ops = Self::default();
-        for i in matches.ids() {
-            match i.as_str() {
-                "verbose" => {
-                    if matches.get_flag(i.as_str()) {
-                        ops.options_mut().push(TarOption::Verbose);
-                    }
-                }
-                "files" => {
-                    if let Some(files) = matches.get_many::<PathBuf>(i.as_str()) {
-                        for file in files {
-                            fp.push(file.to_owned());
-                        }
-                    }
-                    ops.files_mut().append(&mut fp);
-                }
-                "file" => {
-                    if let Some(a) = matches.get_one::<PathBuf>(i.as_str()) {
-                        ops.archive = a.to_owned();
-                    }
-                }
-                _ => {}
-            }
+
+        // -v --verbose
+        if matches.get_flag("verbose") {
+            ops.options_mut().push(TarOption::Verbose);
         }
+
+        // [FILES]...
+        if let Some(files) = matches.get_many::<PathBuf>("files") {
+            ops.files = files.map(|x| x.to_owned()).collect();
+        }
+
+        // -f --file
+        if let Some(a) = matches.get_one::<PathBuf>("file") {
+            ops.archive = a.to_owned();
+        }
+
         ops
     }
 }

--- a/src/uu/tar/src/options/options.rs
+++ b/src/uu/tar/src/options/options.rs
@@ -1,0 +1,92 @@
+use crate::errors::TarError;
+use crate::operations::OperationKind;
+use clap::ArgMatches;
+use std::path::PathBuf;
+use uucore::error::UResult;
+
+/// [`TarParams`] Holds common information that is parsed from
+/// command line arguments. That changes the current execution of
+/// tar.
+#[allow(dead_code)]
+#[derive(Default)]
+pub struct TarParams {
+    archive: PathBuf,
+    files: Vec<PathBuf>,
+    options: Vec<TarOption>,
+}
+
+impl From<&ArgMatches> for TarParams {
+    fn from(matches: &ArgMatches) -> TarParams {
+        let mut ops = Self::default();
+
+        // -v --verbose
+        if matches.get_flag("verbose") {
+            ops.options_mut().push(TarOption::Verbose);
+        }
+
+        // [FILES]...
+        if let Some(files) = matches.get_many::<PathBuf>("files") {
+            ops.files = files.map(|x| x.to_owned()).collect();
+        }
+
+        // -f --file
+        if let Some(a) = matches.get_one::<PathBuf>("file") {
+            ops.archive = a.to_owned();
+        }
+
+        ops
+    }
+}
+
+impl TarParams {
+    /// Convence method that parses the [`ArgMatches`]
+    /// processed by clap into [`TarParams`] and selects
+    /// the appropriate [`OperationKind`] for execution given back to the caller in a
+    /// tuple of ([`OperationKind`], [`TarParams`])
+    pub fn with_operation(matches: &ArgMatches) -> UResult<(OperationKind, Self)> {
+        if matches.get_flag("create") {
+            Ok((OperationKind::Create, Self::from(matches)))
+        } else if matches.get_flag("extract") {
+            Ok((OperationKind::Extract, Self::from(matches)))
+        } else {
+            // TODO: update messaging
+            Err(Box::new(TarError::TarOperationError(
+                "Error processing: Operations".to_string(),
+            )))
+        }
+    }
+}
+
+#[allow(dead_code)]
+impl TarParams {
+    pub fn files(&self) -> &Vec<PathBuf> {
+        &self.files
+    }
+    pub fn files_mut(&mut self) -> &mut Vec<PathBuf> {
+        &mut self.files
+    }
+    pub fn archive(&self) -> &PathBuf {
+        &self.archive
+    }
+    pub fn archive_mut(&mut self) -> &mut PathBuf {
+        &mut self.archive
+    }
+    pub fn options(&self) -> &Vec<TarOption> {
+        &self.options
+    }
+    pub fn options_mut(&mut self) -> &mut Vec<TarOption> {
+        &mut self.options
+    }
+}
+
+/// [`TarOption`] Enum of avaliable tar options for later use
+/// by [`TarOperation`] impls, eg. List, Create, Delete
+#[allow(dead_code)]
+pub enum TarOption {
+    AbsoluteNames,
+    ACLs,
+    AfterDate,
+    Anchored,
+    AtimePreserve { arg: String },
+    Verbose,
+}

--- a/src/uu/tar/src/options/options.rs
+++ b/src/uu/tar/src/options/options.rs
@@ -15,16 +15,6 @@ pub struct TarParams {
     options: Vec<TarOption>,
 }
 
-impl Default for TarParams {
-    fn default() -> TarParams {
-        Self {
-            archive: PathBuf::default(),
-            options: Vec::new(),
-            files: Vec::new(),
-        }
-    }
-}
-
 impl From<&ArgMatches> for TarParams {
     fn from(matches: &ArgMatches) -> TarParams {
         let mut ops = Self::default();

--- a/src/uu/tar/src/options/options.rs
+++ b/src/uu/tar/src/options/options.rs
@@ -1,0 +1,114 @@
+use crate::errors::TarError;
+use crate::operations::OperationKind;
+use clap::ArgMatches;
+use std::path::PathBuf;
+use uucore::error::UResult;
+
+/// [`TarParams`] Holds common information that is parsed from
+/// command line arguments. That changes the current execution of
+/// tar.
+#[allow(dead_code)]
+pub struct TarParams {
+    archive: PathBuf,
+    files: Vec<PathBuf>,
+    options: Vec<TarOption>,
+}
+
+/// [`Default`] Produces safe default values for [`TarParams`] and [`TarOption`]s
+/// for this tar execution. Block-Size of 512 bytes, Empty vec's of
+/// options and file names.
+impl Default for TarParams {
+    fn default() -> TarParams {
+        Self {
+            archive: PathBuf::default(),
+            options: Vec::new(),
+            files: Vec::new(),
+        }
+    }
+}
+
+// NOTE: I feel like this is just reimplmenting the parsing functionality of
+// clap
+impl From<&ArgMatches> for TarParams {
+    fn from(matches: &ArgMatches) -> TarParams {
+        let mut fp = vec![];
+        let mut ops = Self::default();
+        for i in matches.ids() {
+            match i.as_str() {
+                "verbose" => {
+                    if matches.get_flag(i.as_str()) {
+                        ops.options_mut().push(TarOption::Verbose);
+                    }
+                }
+                "files" => {
+                    if let Some(files) = matches.get_many::<PathBuf>(i.as_str()) {
+                        for file in files {
+                            fp.push(file.to_owned());
+                        }
+                    }
+                    ops.files_mut().append(&mut fp);
+                }
+                "file" => {
+                    if let Some(a) = matches.get_one::<PathBuf>(i.as_str()) {
+                        ops.archive = a.to_owned();
+                    }
+                }
+                _ => {}
+            }
+        }
+        ops
+    }
+}
+
+impl TarParams {
+    /// Convence method that parses the [`ArgMatches`]
+    /// processed by clap into [`TarParams`] and selects
+    /// the appropriate [`OperationKind`] for execution given back to the caller in a
+    /// tuple of ([`OperationKind`], [`TarParams`])
+    pub fn with_operation(matches: &ArgMatches) -> UResult<(OperationKind, Self)> {
+        if matches.get_flag("create") {
+            Ok((OperationKind::Create, Self::from(matches)))
+        } else if matches.get_flag("extract") {
+            Ok((OperationKind::Extract, Self::from(matches)))
+        } else {
+            // TODO: update messaging
+            Err(Box::new(TarError::TarOperationError(
+                "Error processing: Operations".to_string(),
+            )))
+        }
+    }
+}
+
+#[allow(dead_code)]
+impl TarParams {
+    pub fn files(&self) -> &Vec<PathBuf> {
+        &self.files
+    }
+    pub fn files_mut(&mut self) -> &mut Vec<PathBuf> {
+        &mut self.files
+    }
+    pub fn archive(&self) -> &PathBuf {
+        &self.archive
+    }
+    pub fn archive_mut(&mut self) -> &mut PathBuf {
+        &mut self.archive
+    }
+    pub fn options(&self) -> &Vec<TarOption> {
+        &self.options
+    }
+    pub fn options_mut(&mut self) -> &mut Vec<TarOption> {
+        &mut self.options
+    }
+}
+
+/// [`TarOption`] Enum of avaliable tar options for later use
+/// by [`TarOperation`] impls, eg. List, Create, Delete
+#[allow(dead_code)]
+pub enum TarOption {
+    AbsoluteNames,
+    ACLs,
+    AfterDate,
+    Anchored,
+    AtimePreserve { arg: String },
+    Verbose,
+}

--- a/src/uu/tar/src/options/options.rs
+++ b/src/uu/tar/src/options/options.rs
@@ -8,25 +8,15 @@ use uucore::error::UResult;
 /// command line arguments. That changes the current execution of
 /// tar.
 #[allow(dead_code)]
+#[derive(Default)]
 pub struct TarParams {
     archive: PathBuf,
     files: Vec<PathBuf>,
     options: Vec<TarOption>,
 }
 
-impl Default for TarParams {
-    fn default() -> TarParams {
-        Self {
-            archive: PathBuf::default(),
-            options: Vec::new(),
-            files: Vec::new(),
-        }
-    }
-}
-
 impl From<&ArgMatches> for TarParams {
     fn from(matches: &ArgMatches) -> TarParams {
-
         let mut ops = Self::default();
 
         // -v --verbose

--- a/src/uu/tar/src/tar.rs
+++ b/src/uu/tar/src/tar.rs
@@ -40,7 +40,6 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     op.exec(&options)
 }
-
 #[allow(clippy::cognitive_complexity)]
 pub fn uu_app() -> Command {
     Command::new(uucore::util_name())

--- a/src/uu/tar/src/tar.rs
+++ b/src/uu/tar/src/tar.rs
@@ -40,6 +40,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     op.exec(&options)
 }
+
 #[allow(clippy::cognitive_complexity)]
 pub fn uu_app() -> Command {
     Command::new(uucore::util_name())

--- a/src/uu/tar/src/tar.rs
+++ b/src/uu/tar/src/tar.rs
@@ -5,9 +5,12 @@
 
 pub mod errors;
 mod operations;
+mod options;
 
 use clap::{arg, crate_version, ArgAction, Command};
-use std::path::{Path, PathBuf};
+use operations::operation::TarOperation;
+use options::TarParams;
+use std::path::PathBuf;
 use uucore::error::UResult;
 use uucore::format_usage;
 
@@ -33,45 +36,10 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let matches = uu_app().try_get_matches_from(args_to_parse)?;
 
-    let verbose = matches.get_flag("verbose");
+    let (op, options) = TarParams::with_operation(&matches)?;
 
-    // Handle extract operation
-    if matches.get_flag("extract") {
-        let archive_path = matches.get_one::<PathBuf>("file").ok_or_else(|| {
-            uucore::error::USimpleError::new(1, "option requires an argument -- 'f'")
-        })?;
-
-        return operations::extract::extract_archive(archive_path, verbose);
-    }
-
-    // Handle create operation
-    if matches.get_flag("create") {
-        let archive_path = matches.get_one::<PathBuf>("file").ok_or_else(|| {
-            uucore::error::USimpleError::new(1, "option requires an argument -- 'f'")
-        })?;
-
-        let files: Vec<&Path> = matches
-            .get_many::<PathBuf>("files")
-            .map(|v| v.map(|p| p.as_path()).collect())
-            .unwrap_or_default();
-
-        if files.is_empty() {
-            return Err(uucore::error::USimpleError::new(
-                1,
-                "Cowardly refusing to create an empty archive",
-            ));
-        }
-
-        return operations::create::create_archive(archive_path, &files, verbose);
-    }
-
-    // If no operation specified, show error
-    Err(uucore::error::USimpleError::new(
-        1,
-        "You must specify one of the '-c' or '-x' options",
-    ))
+    op.exec(&options)
 }
-
 #[allow(clippy::cognitive_complexity)]
 pub fn uu_app() -> Command {
     Command::new(uucore::util_name())


### PR DESCRIPTION
This PR builds on the great work done by @kaladron and lays out the foundation to enable adding operations and options moving forward. Leveraging rust enums and building behavioral control with the enum dispatch pattern.

There are 3 critical pieces to this foundational layer.

### TarParams
- TarParams provides highline access to arguments passed in and some convenience to the options set by the user that are called during execution. This also serves as the functional place that clap arguments are processed from uu_main. ArgMatches are pumped in and TarParams, TarOptions, and the TarOperation pop out.
### TarOptions
- An enum used to capture arguments and potential subarguments passed in via clap and command line. Due to the overwhelming amount of options that tar has, we needed a way to store these while also potentially caputuring data that could be associated with that option. Like BlockingFactor might take in a u32, while Verbose is only a flag so its presentance in a list is enough, and a rust enum is the best way to handle this wide swath of possibilities. A Vec of these options is stored in TarParams and created when TarParams::with_operation() is called.
### TarOperation
- This trait serves as the execution hook from processing from clap ArgMatchees to execution. Each Main Operation mode is created as a file (create.rs, extract.rs) and each of these have a new type associated with their respected operation. Which then impl the TarOperation trait and the exec method. This gives us a place to call our main operation modes and decouple each operation from one another, but also allowing the reuse of operations in other operations. For example, using append in the update operation.

While this is just the bones it will continue to morph and change as more functionality is built into tar.