### PR TITLE
Remove `uuhelp_parser` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1271,7 +1271,6 @@ dependencies = [
  "textwrap",
  "uu_tar",
  "uucore",
- "uuhelp_parser",
  "uutests",
  "xattr",
  "zip",
@@ -1487,12 +1486,6 @@ dependencies = [
  "proc-macro2",
  "quote",
 ]
-
-[[package]]
-name = "uuhelp_parser"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e4945611996e885dc4eeae23f3d6f20cfb6e8f4bad4985c2222bbcf9a9745"
 
 [[package]]
 name = "uutests"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ build = "build.rs"
 
 [features]
 default = ["feat_common_core"]
-uudoc = ["zip", "uuhelp_parser"]
+uudoc = ["zip"]
 
 feat_common_core = [
   "tar",
@@ -44,7 +44,6 @@ phf_codegen = "0.13.0"
 rand = { version = "0.10.0" }
 regex = "1.10.4"
 uucore = "0.6.0"
-uuhelp_parser = "0.2.0"
 uutests = "0.6.0"
 tar = "0.4"
 tempfile = "3.10.1"
@@ -61,7 +60,6 @@ phf = { workspace = true }
 textwrap = { workspace = true }
 uutests = { workspace = true }
 uucore = { workspace = true }
-uuhelp_parser = { workspace = true, optional = true }
 zip = { workspace = true, optional = true }
 
 tar = { optional = true, version = "0.0.1", package = "uu_tar", path = "src/uu/tar" }


### PR DESCRIPTION
This PR removes the `uuhelp_parser` dependency: it's unused and the project itself no longer exists.