### PR TITLE
Cargo.toml: Move codegen-units to release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,18 +101,17 @@ required-features = ["uudoc"]
 # release profile), the debug info and the stack traces will still be available.
 [profile.release]
 lto = true
+codegen-units = 1
 
 # A release-like profile that is tuned to be fast, even when being fast
 # compromises on binary size. This includes aborting on panic.
 [profile.release-fast]
 inherits = "release"
 panic = "abort"
-codegen-units = 1
 
 # A release-like profile that is as small as possible.
 [profile.release-small]
 inherits = "release"
 opt-level = "z"
 panic = "abort"
-codegen-units = 1
 strip = true


### PR DESCRIPTION
No reason to avoid this by default.