### PR TITLE
Remove "creating archive" output

### DIFF
--- a/src/uu/tar/src/operations/create.rs
+++ b/src/uu/tar/src/operations/create.rs
@@ -37,10 +37,6 @@ pub fn create_archive(archive_path: &Path, files: &[&Path], verbose: bool) -> UR
     // Create Builder instance
     let mut builder = Builder::new(file);
 
-    if verbose {
-        println!("Creating archive: {}", archive_path.display());
-    }
-
     // Add each file or directory to the archive
     for &path in files {
         // Check if path exists


### PR DESCRIPTION
While reviewing https://github.com/uutils/tar/pull/62 I noticed that we output `Creating archive: <filename>` in verbose mode, whereas GNU `tar` doesn't. This PR removes the message.
