### PR TITLE
Bump `rlimit` from `0.10.1` to `0.11.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -967,6 +967,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rlimit"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f35ee2729c56bb610f6dba436bf78135f728b7373bdffae2ec815b2d3eb98cc3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "roff"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1144,7 +1153,7 @@ dependencies = [
  "pretty_assertions",
  "rand",
  "regex",
- "rlimit",
+ "rlimit 0.11.0",
  "tar",
  "tempfile",
  "textwrap",
@@ -1380,7 +1389,7 @@ dependencies = [
  "pretty_assertions",
  "rand",
  "regex",
- "rlimit",
+ "rlimit 0.10.2",
  "tempfile",
  "uucore",
  "xattr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ uutests = { workspace = true }
 xattr = { workspace = true }
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dev-dependencies]
-rlimit = "0.10.1"
+rlimit = "0.11.0"
 
 [build-dependencies]
 phf_codegen = { workspace = true }


### PR DESCRIPTION
This PR manually bumps `rlimit` from `0.10.1` to `0.11.0` because renovate fails with an "Artifact update problem" in https://github.com/uutils/tar/pull/83