### PR TITLE
ci: remove (almost) duplicate fmt job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,15 +30,6 @@ jobs:
       - uses: actions/checkout@v6
       - run: cargo test --all
 
-  fmt:
-    name: cargo fmt --all -- --check
-    runs-on: ubuntu-latest
-    env:
-      CARGO_INCREMENTAL: 0
-    steps:
-      - uses: actions/checkout@v6
-      - run: cargo fmt --all -- --check
-
   coverage:
     name: Code Coverage
     runs-on: ${{ matrix.job.os }}

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -23,39 +23,12 @@ concurrency:
 jobs:
   style_format:
     name: Style/format
-    runs-on: ${{ matrix.job.os }}
+    runs-on: ubuntu-latest
     env:
       CARGO_INCREMENTAL: 0
-    strategy:
-      fail-fast: false
-      matrix:
-        job:
-          - { os: ubuntu-latest, features: feat_os_unix }
     steps:
       - uses: actions/checkout@v6
-      - uses: Swatinem/rust-cache@v2
-      - name: Initialize workflow variables
-        id: vars
-        shell: bash
-        run: |
-          ## VARs setup
-          outputs() { step_id="${{ github.action }}"; for var in "$@" ; do echo steps.${step_id}.outputs.${var}="${!var}"; echo "${var}=${!var}" >> $GITHUB_OUTPUT; done; }
-          # failure mode
-          unset FAIL_ON_FAULT ; case '${{ env.STYLE_FAIL_ON_FAULT }}' in
-            ''|0|f|false|n|no|off) FAULT_TYPE=warning ;;
-            *) FAIL_ON_FAULT=true ; FAULT_TYPE=error ;;
-          esac;
-          outputs FAIL_ON_FAULT FAULT_TYPE
-      - name: "`cargo fmt` testing"
-        shell: bash
-        run: |
-          ## `cargo fmt` testing
-          unset fault
-          fault_type="${{ steps.vars.outputs.FAULT_TYPE }}"
-          fault_prefix=$(echo "$fault_type" | tr '[:lower:]' '[:upper:]')
-          # * convert any errors/warnings to GHA UI annotations; ref: <https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-a-warning-message>
-          S=$(cargo fmt -- --check) && printf "%s\n" "$S" || { printf "%s\n" "$S" ; printf "%s\n" "$S" | sed -E -n -e "s/^Diff[[:space:]]+in[[:space:]]+${PWD//\//\\/}\/(.*)[[:space:]]+at[[:space:]]+[^0-9]+([0-9]+).*$/::${fault_type} file=\1,line=\2::${fault_prefix}: \`cargo fmt\`: style violation (file:'\1', line:\2; use \`cargo fmt -- \"\1\"\`)/p" ; fault=true ; }
-          if [ -n "${{ steps.vars.outputs.FAIL_ON_FAULT }}" ] && [ -n "$fault" ]; then exit 1 ; fi
+      - run: cargo fmt --all -- --check
 
   style_lint:
     name: Style/lint


### PR DESCRIPTION
Currently, we have two jobs that run `cargo fmt`: one in `ci.yml` and one in `code-quality.yml`.

This PR replaces the job in `code-quality.yml` with the one from `ci.yml` because that job is much easier to read and does more or less the same.