### PR TITLE
Bump Rust version to `1.94.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/uutils/tar"
 readme = "README.md"
 keywords = ["tar", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 edition = "2024"
 
 build = "build.rs"


### PR DESCRIPTION
This PR bumps the Rust version from `1.85.0` to `1.94.0`. `uucore` and `uutests` have an MSRV of `1.88.0` and as the version currently doesn't matter that much without having a release, I bumped it to the current stable version.