### PR TITLE
tar: add explicit zstd compression support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1434,6 +1434,7 @@ dependencies = [
  "uutests",
  "xattr",
  "zip",
+ "zstd",
 ]
 
 [[package]]
@@ -1646,6 +1647,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "uucore",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ uucore = { git = "https://github.com/uutils/coreutils" }
 uutests = { git = "https://github.com/uutils/coreutils" }
 xattr = "1.3.1"
 zip = "8.0"
+zstd = "0.13.3"
 
 [dependencies]
 clap = { workspace = true }
@@ -77,6 +78,7 @@ tar-rs-crate = { version = "0.4", package = "tar" }
 tempfile = { workspace = true }
 uucore = { workspace = true, features = ["entries", "process", "signals"] }
 uutests = { workspace = true }
+zstd = { workspace = true }
 
 [target.'cfg(unix)'.dev-dependencies]
 xattr = { workspace = true }

--- a/benches/bench_tar.rs
+++ b/benches/bench_tar.rs
@@ -6,6 +6,7 @@
 use std::fs::{self, File};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
+use tar::CompressionMode;
 use tar::operations;
 use tempfile::TempDir;
 
@@ -41,7 +42,15 @@ fn build_archive(archive_path: &Path, source_dir: &Path) {
     let refs: Vec<&Path> = files.iter().map(|p| p.as_path()).collect();
     let output = File::create(archive_path).unwrap();
     let status_output = io::sink();
-    operations::create::create_archive(output, status_output, &refs, true, false).unwrap();
+    operations::create::create_archive(
+        output,
+        status_output,
+        &refs,
+        true,
+        false,
+        CompressionMode::None,
+    )
+    .unwrap();
 }
 
 // ---------------------------------------------------------------------------
@@ -61,7 +70,15 @@ fn create_archive_10_files(bencher: divan::Bencher) {
         let refs: Vec<&Path> = files.iter().map(|p| p.as_path()).collect();
         let output = File::create(&archive_path).unwrap();
         let status_output = io::sink();
-        operations::create::create_archive(output, status_output, &refs, true, false).unwrap();
+        operations::create::create_archive(
+            output,
+            status_output,
+            &refs,
+            true,
+            false,
+            CompressionMode::None,
+        )
+        .unwrap();
     });
 }
 
@@ -78,7 +95,15 @@ fn create_archive_100_files(bencher: divan::Bencher) {
         let refs: Vec<&Path> = files.iter().map(|p| p.as_path()).collect();
         let output = File::create(&archive_path).unwrap();
         let status_output = io::sink();
-        operations::create::create_archive(output, status_output, &refs, true, false).unwrap();
+        operations::create::create_archive(
+            output,
+            status_output,
+            &refs,
+            true,
+            false,
+            CompressionMode::None,
+        )
+        .unwrap();
     });
 }
 
@@ -95,8 +120,15 @@ fn create_archive_directory(bencher: divan::Bencher) {
     bencher.bench_local(|| {
         let output = File::create(&archive_path).unwrap();
         let status_output = io::sink();
-        operations::create::create_archive(output, status_output, &[sub.as_path()], true, false)
-            .unwrap();
+        operations::create::create_archive(
+            output,
+            status_output,
+            &[sub.as_path()],
+            true,
+            false,
+            CompressionMode::None,
+        )
+        .unwrap();
     });
 }
 
@@ -114,7 +146,7 @@ fn list_archive_50_files(bencher: divan::Bencher) {
 
     bencher.bench_local(|| {
         let input = File::open(&archive_path).unwrap();
-        operations::list::list_archive(input, false).unwrap();
+        operations::list::list_archive(input, &archive_path, false, CompressionMode::None).unwrap();
     });
 }
 
@@ -128,7 +160,7 @@ fn list_archive_verbose_50_files(bencher: divan::Bencher) {
 
     bencher.bench_local(|| {
         let input = File::open(&archive_path).unwrap();
-        operations::list::list_archive(input, true).unwrap();
+        operations::list::list_archive(input, &archive_path, true, CompressionMode::None).unwrap();
     });
 }
 
@@ -150,7 +182,13 @@ fn extract_archive_20_files(bencher: divan::Bencher) {
         .bench_local_values(|extract_dir| {
             std::env::set_current_dir(extract_dir.path()).unwrap();
             let input = File::open(&archive_path).unwrap();
-            operations::extract::extract_archive(input, &archive_path, false).unwrap();
+            operations::extract::extract_archive(
+                input,
+                &archive_path,
+                false,
+                CompressionMode::None,
+            )
+            .unwrap();
         });
     std::env::set_current_dir(original_dir).unwrap();
 }

--- a/src/uu/tar/Cargo.toml
+++ b/src/uu/tar/Cargo.toml
@@ -19,6 +19,7 @@ regex = { workspace = true }
 tar = { workspace = true }
 chrono = { workspace = true }
 thiserror = { workspace = true }
+zstd = { workspace = true }
 
 [lib]
 path = "src/tar.rs"

--- a/src/uu/tar/src/errors.rs
+++ b/src/uu/tar/src/errors.rs
@@ -27,6 +27,10 @@ pub enum TarError {
     #[error("tar: Cannot read entry path: {0}")]
     CannotReadEntryPath(io::Error),
 
+    /// Invalid archive format or corrupted archive
+    #[error("tar: {0}")]
+    InvalidArchive(String),
+
     /// File or directory not found
     #[error("tar: {path}: Cannot open: No such file or directory")]
     FileNotFound { path: PathBuf },
@@ -50,6 +54,10 @@ pub enum TarError {
     /// Cannot extract an archive entry
     #[error("tar: Cannot extract '{path}': {source}")]
     CannotExtract { path: PathBuf, source: io::Error },
+
+    /// General tar operation error
+    #[error("tar: {0}")]
+    TarOperationError(String),
 
     /// Cannot finalize the archive
     #[error("tar: Cannot finalize archive: {0}")]

--- a/src/uu/tar/src/operations/compression.rs
+++ b/src/uu/tar/src/operations/compression.rs
@@ -1,0 +1,134 @@
+// This file is part of the uutils tar package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+use crate::errors::TarError;
+use crate::CompressionMode;
+use std::io::{BufReader, Read, Write};
+use std::path::Path;
+
+pub(crate) fn open_archive_reader<'a, R: Read + 'a>(
+    input: R,
+    archive_path: &Path,
+    compression: CompressionMode,
+) -> Result<Box<dyn Read + 'a>, TarError> {
+    match compression {
+        CompressionMode::None => Ok(Box::new(BufReader::new(input))),
+        CompressionMode::Zstd => {
+            let decoder = zstd::stream::read::Decoder::new(input).map_err(|e| {
+                TarError::InvalidArchive(format!(
+                    "Failed to initialize zstd decoder for '{}': {}",
+                    archive_path.display(),
+                    e
+                ))
+            })?;
+            Ok(Box::new(decoder))
+        }
+    }
+}
+
+pub(crate) struct ArchiveWriter<W: Write> {
+    inner: ArchiveWriterInner<W>,
+}
+
+enum ArchiveWriterInner<W: Write> {
+    Plain(W),
+    Zstd(zstd::stream::write::Encoder<'static, W>),
+}
+
+impl<W: Write> ArchiveWriter<W> {
+    pub(crate) fn new(output: W, compression: CompressionMode) -> Result<Self, TarError> {
+        let inner = match compression {
+            CompressionMode::None => ArchiveWriterInner::Plain(output),
+            CompressionMode::Zstd => {
+                let encoder = zstd::stream::write::Encoder::new(output, 0).map_err(|e| {
+                    TarError::TarOperationError(format!("Failed to initialize zstd encoder: {e}"))
+                })?;
+                ArchiveWriterInner::Zstd(encoder)
+            }
+        };
+
+        Ok(Self { inner })
+    }
+
+    pub fn finish(self) -> Result<(), TarError> {
+        match self.inner {
+            ArchiveWriterInner::Plain(mut output) => output.flush().map_err(TarError::Io),
+            ArchiveWriterInner::Zstd(encoder) => encoder.finish().map(|_| ()).map_err(|e| {
+                TarError::TarOperationError(format!("Failed to finalize zstd archive: {e}"))
+            }),
+        }
+    }
+}
+
+impl<W: Write> Write for ArchiveWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        match &mut self.inner {
+            ArchiveWriterInner::Plain(file) => file.write(buf),
+            ArchiveWriterInner::Zstd(encoder) => encoder.write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        match &mut self.inner {
+            ArchiveWriterInner::Plain(file) => file.flush(),
+            ArchiveWriterInner::Zstd(encoder) => encoder.flush(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_plain_archive_writer_and_reader() {
+        let tempdir = tempdir().unwrap();
+        let archive_path = tempdir.path().join("plain.tar");
+
+        let output = std::fs::File::create(&archive_path).unwrap();
+        let mut writer = ArchiveWriter::new(output, CompressionMode::None).unwrap();
+        writer.write_all(b"plain data").unwrap();
+        writer.flush().unwrap();
+        writer.finish().unwrap();
+
+        let input = std::fs::File::open(&archive_path).unwrap();
+        let mut reader = open_archive_reader(input, &archive_path, CompressionMode::None).unwrap();
+        let mut contents = Vec::new();
+        reader.read_to_end(&mut contents).unwrap();
+        assert_eq!(contents, b"plain data");
+    }
+
+    #[test]
+    fn test_zstd_archive_writer_and_reader() {
+        let tempdir = tempdir().unwrap();
+        let archive_path = tempdir.path().join("archive.tar.zst");
+
+        let output = std::fs::File::create(&archive_path).unwrap();
+        let mut writer = ArchiveWriter::new(output, CompressionMode::Zstd).unwrap();
+        writer.write_all(b"zstd data").unwrap();
+        writer.flush().unwrap();
+        writer.finish().unwrap();
+
+        let input = std::fs::File::open(&archive_path).unwrap();
+        let mut reader = open_archive_reader(input, &archive_path, CompressionMode::Zstd).unwrap();
+        let mut contents = Vec::new();
+        reader.read_to_end(&mut contents).unwrap();
+        assert_eq!(contents, b"zstd data");
+    }
+
+    #[test]
+    fn test_open_archive_reader_invalid_zstd_stream_fails_on_read() {
+        let tempdir = tempdir().unwrap();
+        let archive_path = tempdir.path().join("invalid.tar.zst");
+        std::fs::write(&archive_path, b"not zstd").unwrap();
+
+        let input = std::fs::File::open(&archive_path).unwrap();
+        let mut reader = open_archive_reader(input, &archive_path, CompressionMode::Zstd).unwrap();
+        let mut contents = Vec::new();
+        assert!(reader.read_to_end(&mut contents).is_err());
+    }
+}

--- a/src/uu/tar/src/operations/create.rs
+++ b/src/uu/tar/src/operations/create.rs
@@ -4,6 +4,8 @@
 // file that was distributed with this source code.
 
 use crate::errors::TarError;
+use crate::operations::compression::ArchiveWriter;
+use crate::CompressionMode;
 use std::collections::VecDeque;
 use std::fs;
 use std::io::{BufWriter, Write};
@@ -16,7 +18,7 @@ use uucore::error::UResult;
 ///
 /// # Arguments
 ///
-/// * `archive_path` - Path where the tar archive should be created
+/// * `output` - Destination where the tar archive should be written
 /// * `files` - Slice of file paths to add to the archive
 /// * `allow_absolute` - Allow absolute paths while creating archive
 /// * `verbose` - Whether to print verbose output during creation
@@ -27,13 +29,15 @@ use uucore::error::UResult;
 /// - The archive file cannot be created
 /// - Any input file cannot be read
 /// - Files cannot be added due to I/O or permission errors
-pub fn create_archive(
+pub(crate) fn create_archive(
     output: impl Write,
     status_output: impl Write,
     files: &[&Path],
     allow_absolute: bool,
     verbose: bool,
+    compression: CompressionMode,
 ) -> UResult<()> {
+    let output = ArchiveWriter::new(output, compression)?;
     let mut output = BufWriter::new(output);
     let mut status_output = BufWriter::new(status_output);
 
@@ -113,6 +117,10 @@ pub fn create_archive(
 
     status_output.flush().map_err(TarError::Io)?;
     output.flush().map_err(TarError::Io)?;
+    let output = output
+        .into_inner()
+        .map_err(|e| TarError::Io(e.into_error()))?;
+    output.finish()?;
 
     Ok(())
 }
@@ -146,11 +154,13 @@ fn normalize_path(path: &Path, allow_absolute: bool) -> Option<PathBuf> {
         None
     }
 }
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::io::{self, Write};
-    use tempfile::TempDir;
+    use tar::Archive;
+    use tempfile::{tempdir, TempDir};
 
     struct FailFlushWriter;
     impl Write for FailFlushWriter {
@@ -171,7 +181,55 @@ mod tests {
         let output = FailFlushWriter;
         let status_output = io::sink();
 
-        let res = create_archive(output, status_output, &[file_path.as_path()], false, false);
+        let res = create_archive(
+            output,
+            status_output,
+            &[file_path.as_path()],
+            false,
+            false,
+            CompressionMode::None,
+        );
         assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_create_archive_with_zstd() {
+        let tempdir = tempdir().unwrap();
+        let _guard = crate::operations::TestDirGuard::enter(tempdir.path());
+        fs::write("file.txt", "hello").unwrap();
+
+        create_archive(
+            fs::File::create("archive.tar.zst").unwrap(),
+            io::sink(),
+            &[Path::new("file.txt")],
+            false,
+            false,
+            CompressionMode::Zstd,
+        )
+        .unwrap();
+
+        let decoder =
+            zstd::stream::read::Decoder::new(fs::File::open("archive.tar.zst").unwrap()).unwrap();
+        let mut archive = Archive::new(decoder);
+        let mut entries = archive.entries().unwrap();
+        let entry = entries.next().unwrap().unwrap();
+        assert_eq!(entry.path().unwrap().to_str(), Some("file.txt"));
+    }
+
+    #[test]
+    fn test_create_archive_missing_file_fails() {
+        let tempdir = tempdir().unwrap();
+        let missing_path = tempdir.path().join("missing.txt");
+
+        let err = create_archive(
+            io::sink(),
+            io::sink(),
+            &[missing_path.as_path()],
+            false,
+            false,
+            CompressionMode::Zstd,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("missing.txt"));
     }
 }

--- a/src/uu/tar/src/operations/create.rs
+++ b/src/uu/tar/src/operations/create.rs
@@ -29,7 +29,7 @@ use uucore::error::UResult;
 /// - The archive file cannot be created
 /// - Any input file cannot be read
 /// - Files cannot be added due to I/O or permission errors
-pub(crate) fn create_archive(
+pub fn create_archive(
     output: impl Write,
     status_output: impl Write,
     files: &[&Path],

--- a/src/uu/tar/src/operations/extract.rs
+++ b/src/uu/tar/src/operations/extract.rs
@@ -24,7 +24,7 @@ use uucore::error::UResult;
 /// - The archive file cannot be opened
 /// - The archive format is invalid
 /// - Files cannot be extracted due to I/O or permission errors
-pub(crate) fn extract_archive(
+pub fn extract_archive(
     input: impl Read,
     archive_path: &Path,
     verbose: bool,

--- a/src/uu/tar/src/operations/extract.rs
+++ b/src/uu/tar/src/operations/extract.rs
@@ -4,7 +4,9 @@
 // file that was distributed with this source code.
 
 use crate::errors::TarError;
-use std::io::{self, BufReader, BufWriter, Read, Write};
+use crate::operations::compression::open_archive_reader;
+use crate::CompressionMode;
+use std::io::{self, BufWriter, Read, Write};
 use std::path::Path;
 use tar::Archive;
 use uucore::error::UResult;
@@ -22,9 +24,14 @@ use uucore::error::UResult;
 /// - The archive file cannot be opened
 /// - The archive format is invalid
 /// - Files cannot be extracted due to I/O or permission errors
-pub fn extract_archive(input: impl Read, archive_path: &Path, verbose: bool) -> UResult<()> {
-    // Create Archive instance
-    let mut archive = Archive::new(BufReader::new(input));
+pub(crate) fn extract_archive(
+    input: impl Read,
+    archive_path: &Path,
+    verbose: bool,
+    compression: CompressionMode,
+) -> UResult<()> {
+    let reader = open_archive_reader(input, archive_path, compression)?;
+    let mut archive = Archive::new(reader);
     let mut out = BufWriter::new(io::stdout().lock());
 
     // Extract to current directory
@@ -55,4 +62,44 @@ pub fn extract_archive(input: impl Read, archive_path: &Path, verbose: bool) -> 
 
     out.flush().map_err(TarError::Io)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::CompressionMode;
+    use std::fs;
+    use tar::Builder;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_extract_archive_with_zstd() {
+        let tempdir = tempdir().unwrap();
+        let archive_path = tempdir.path().join("archive.tar.zst");
+
+        let mut tar_bytes = Vec::new();
+        {
+            let mut builder = Builder::new(&mut tar_bytes);
+            let mut header = tar::Header::new_gnu();
+            header.set_mode(0o644);
+            header.set_size("hello".len() as u64);
+            header.set_cksum();
+            builder
+                .append_data(&mut header, "extracted.txt", std::io::Cursor::new("hello"))
+                .unwrap();
+            builder.finish().unwrap();
+        }
+        let compressed = zstd::stream::encode_all(std::io::Cursor::new(tar_bytes), 0).unwrap();
+        fs::write(&archive_path, compressed).unwrap();
+
+        let _guard = crate::operations::TestDirGuard::enter(tempdir.path());
+        let input = fs::File::open(&archive_path).unwrap();
+        let result = extract_archive(input, &archive_path, true, CompressionMode::Zstd);
+
+        result.unwrap();
+        assert_eq!(
+            fs::read_to_string(tempdir.path().join("extracted.txt")).unwrap(),
+            "hello"
+        );
+    }
 }

--- a/src/uu/tar/src/operations/list.rs
+++ b/src/uu/tar/src/operations/list.rs
@@ -14,7 +14,7 @@ use uucore::error::UResult;
 use uucore::fs::display_permissions_unix;
 
 /// List the contents of a tar archive, printing one entry per line.
-pub(crate) fn list_archive(
+pub fn list_archive(
     input: impl Read,
     archive_path: &Path,
     verbose: bool,

--- a/src/uu/tar/src/operations/list.rs
+++ b/src/uu/tar/src/operations/list.rs
@@ -4,15 +4,24 @@
 // file that was distributed with this source code.
 
 use crate::errors::TarError;
+use crate::operations::compression::open_archive_reader;
+use crate::CompressionMode;
 use chrono::{TimeZone, Utc};
-use std::io::{self, BufReader, BufWriter, Read, Write};
+use std::io::{self, BufWriter, Read, Write};
+use std::path::Path;
 use tar::Archive;
 use uucore::error::UResult;
 use uucore::fs::display_permissions_unix;
 
 /// List the contents of a tar archive, printing one entry per line.
-pub fn list_archive(input: impl Read, verbose: bool) -> UResult<()> {
-    let mut archive = Archive::new(BufReader::new(input));
+pub(crate) fn list_archive(
+    input: impl Read,
+    archive_path: &Path,
+    verbose: bool,
+    compression: CompressionMode,
+) -> UResult<()> {
+    let reader = open_archive_reader(input, archive_path, compression)?;
+    let mut archive = Archive::new(reader);
     let mut out = BufWriter::new(io::stdout().lock());
 
     for entry_result in archive.entries().map_err(TarError::CannotReadEntries)? {
@@ -81,4 +90,50 @@ pub fn list_archive(input: impl Read, verbose: bool) -> UResult<()> {
 
     out.flush().map_err(TarError::Io)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::CompressionMode;
+    use std::fs;
+    use tar::Builder;
+    use tempfile::tempdir;
+
+    fn write_zstd_tar(archive_path: &Path) {
+        let mut tar_bytes = Vec::new();
+        {
+            let mut builder = Builder::new(&mut tar_bytes);
+            let mut header = tar::Header::new_gnu();
+            header.set_mode(0o644);
+            header.set_size("hello".len() as u64);
+            header.set_cksum();
+            builder
+                .append_data(&mut header, "listed.txt", std::io::Cursor::new("hello"))
+                .unwrap();
+            builder.finish().unwrap();
+        }
+        let compressed = zstd::stream::encode_all(std::io::Cursor::new(tar_bytes), 0).unwrap();
+        fs::write(archive_path, compressed).unwrap();
+    }
+
+    #[test]
+    fn test_list_archive_with_zstd_non_verbose() {
+        let tempdir = tempdir().unwrap();
+        let archive_path = tempdir.path().join("archive.tar.zst");
+        write_zstd_tar(&archive_path);
+
+        let input = fs::File::open(&archive_path).unwrap();
+        list_archive(input, &archive_path, false, CompressionMode::Zstd).unwrap();
+    }
+
+    #[test]
+    fn test_list_archive_with_zstd_verbose() {
+        let tempdir = tempdir().unwrap();
+        let archive_path = tempdir.path().join("archive.tar.zst");
+        write_zstd_tar(&archive_path);
+
+        let input = fs::File::open(&archive_path).unwrap();
+        list_archive(input, &archive_path, true, CompressionMode::Zstd).unwrap();
+    }
 }

--- a/src/uu/tar/src/operations/mod.rs
+++ b/src/uu/tar/src/operations/mod.rs
@@ -3,6 +3,44 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
+#[cfg(test)]
+use std::path::{Path, PathBuf};
+#[cfg(test)]
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+pub mod compression;
 pub mod create;
 pub mod extract;
 pub mod list;
+
+#[cfg(test)]
+pub(crate) fn test_cwd_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+#[cfg(test)]
+pub(crate) struct TestDirGuard {
+    old_dir: PathBuf,
+    _guard: MutexGuard<'static, ()>,
+}
+
+#[cfg(test)]
+impl TestDirGuard {
+    pub(crate) fn enter(path: &Path) -> Self {
+        let guard = test_cwd_lock().lock().unwrap();
+        let old_dir = std::env::current_dir().unwrap();
+        std::env::set_current_dir(path).unwrap();
+        Self {
+            old_dir,
+            _guard: guard,
+        }
+    }
+}
+
+#[cfg(test)]
+impl Drop for TestDirGuard {
+    fn drop(&mut self) {
+        let _ = std::env::set_current_dir(&self.old_dir);
+    }
+}

--- a/src/uu/tar/src/tar.rs
+++ b/src/uu/tar/src/tar.rs
@@ -18,7 +18,7 @@ const ABOUT: &str = "an archiving utility";
 const USAGE: &str = "tar key [FILE...]\n       tar {-c|-t|-x} [-v] -f ARCHIVE [FILE...]";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum CompressionMode {
+pub enum CompressionMode {
     None,
     Zstd,
 }

--- a/src/uu/tar/src/tar.rs
+++ b/src/uu/tar/src/tar.rs
@@ -17,6 +17,12 @@ use uucore::format_usage;
 const ABOUT: &str = "an archiving utility";
 const USAGE: &str = "tar key [FILE...]\n       tar {-c|-t|-x} [-v] -f ARCHIVE [FILE...]";
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CompressionMode {
+    None,
+    Zstd,
+}
+
 /// Determines whether a string looks like a POSIX tar keystring.
 ///
 /// A valid keystring must not start with '-', must contain at least one
@@ -135,6 +141,11 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let verbose = matches.get_flag("verbose");
     let allow_absolute = matches.get_flag("absolute-names");
+    let compression = if matches.get_flag("zstd") {
+        CompressionMode::Zstd
+    } else {
+        CompressionMode::None
+    };
 
     // Handle extract operation
     if matches.get_flag("extract") {
@@ -143,11 +154,11 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         })?;
 
         return if archive_path == Path::new("-") {
-            operations::extract::extract_archive(io::stdin(), archive_path, verbose)
+            operations::extract::extract_archive(io::stdin(), archive_path, verbose, compression)
         } else {
             let file =
                 File::open(archive_path).map_err(|e| TarError::from_io_error(e, archive_path))?;
-            operations::extract::extract_archive(file, archive_path, verbose)
+            operations::extract::extract_archive(file, archive_path, verbose, compression)
         };
     }
 
@@ -182,6 +193,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                     &files,
                     allow_absolute,
                     verbose,
+                    compression,
                 )
             }
         } else {
@@ -196,6 +208,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 &files,
                 allow_absolute,
                 verbose,
+                compression,
             )
         };
     }
@@ -207,11 +220,11 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         })?;
 
         return if archive_path == Path::new("-") {
-            operations::list::list_archive(io::stdin(), verbose)
+            operations::list::list_archive(io::stdin(), archive_path, verbose, compression)
         } else {
             let file =
                 File::open(archive_path).map_err(|e| TarError::from_io_error(e, archive_path))?;
-            operations::list::list_archive(file, verbose)
+            operations::list::list_archive(file, archive_path, verbose, compression)
         };
     }
 
@@ -251,6 +264,7 @@ pub fn uu_app() -> Command {
             // arg!(-z --gzip "Filter through gzip"),
             // arg!(-j --bzip2 "Filter through bzip2"),
             // arg!(-J --xz "Filter through xz"),
+            arg!(--zstd "Filter through zstd"),
             // Common options
             arg!(-v --verbose "Verbosely list files processed"),
             // arg!(-h --dereference "Follow symlinks"),
@@ -267,6 +281,9 @@ pub fn uu_app() -> Command {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsString;
+    use std::fs;
+    use tempfile::tempdir;
 
     // --- is_posix_keystring ---
 
@@ -374,5 +391,47 @@ mod tests {
         let input = osvec(&["tar", "cbf", "20", "archive.tar", "file.txt"]);
         let expected = osvec(&["tar", "-c", "-b", "20", "-f", "archive.tar", "file.txt"]);
         assert_eq!(expand_posix_keystring(input), expected);
+    }
+
+    #[test]
+    fn test_uumain_dispatches_zstd_create_list_extract() {
+        let tempdir = tempdir().unwrap();
+        let _guard = crate::operations::TestDirGuard::enter(tempdir.path());
+        fs::write("file.txt", "hello").unwrap();
+
+        let create_args = vec![
+            OsString::from("test-bin"),
+            OsString::from("tar"),
+            OsString::from("--zstd"),
+            OsString::from("-cf"),
+            OsString::from("archive.tar.zst"),
+            OsString::from("file.txt"),
+        ];
+        assert_eq!(uumain(create_args.into_iter()), 0);
+
+        let list_args = vec![
+            OsString::from("test-bin"),
+            OsString::from("tar"),
+            OsString::from("--zstd"),
+            OsString::from("-tf"),
+            OsString::from("archive.tar.zst"),
+        ];
+        assert_eq!(uumain(list_args.into_iter()), 0);
+
+        fs::remove_file("file.txt").unwrap();
+        let extract_args = vec![
+            OsString::from("test-bin"),
+            OsString::from("tar"),
+            OsString::from("--zstd"),
+            OsString::from("-xf"),
+            OsString::from("archive.tar.zst"),
+        ];
+        let result = uumain(extract_args.into_iter());
+
+        assert_eq!(result, 0);
+        assert_eq!(
+            fs::read_to_string(tempdir.path().join("file.txt")).unwrap(),
+            "hello"
+        );
     }
 }

--- a/src/uu/tar/tests/test_cli.rs
+++ b/src/uu/tar/tests/test_cli.rs
@@ -32,3 +32,14 @@ fn test_verbose_flag_parsing() {
     assert!(matches.get_flag("verbose"));
     assert!(matches.get_flag("create"));
 }
+
+#[test]
+fn test_zstd_flag_parsing() {
+    let app = uu_app();
+    let result =
+        app.try_get_matches_from(vec!["tar", "--zstd", "-cf", "archive.tar.zst", "file.txt"]);
+    assert!(result.is_ok());
+    let matches = result.unwrap();
+    assert!(matches.get_flag("zstd"));
+    assert!(matches.get_flag("create"));
+}

--- a/tests/by-util/test_tar.rs
+++ b/tests/by-util/test_tar.rs
@@ -3,8 +3,10 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
+use std::io::{Cursor, Read};
 use std::path::{self, PathBuf};
 
+use tar_rs_crate::{Archive as TarRsArchive, Builder as TarRsBuilder, Header as TarRsHeader};
 use uutests::{at_and_ucmd, new_ucmd};
 
 /// Size of a single tar block in bytes (per POSIX specification).
@@ -112,6 +114,44 @@ fn test_create_multiple_files() {
 
     assert!(at.file_exists("archive.tar"));
     assert!(at.read_bytes("archive.tar").len() > TAR_BLOCK_SIZE); // Basic sanity check
+}
+
+#[test]
+fn test_create_zstd_archive() {
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    at.write("file1.txt", "test content");
+
+    ucmd.args(&["--zstd", "-cf", "archive.tar.zst", "file1.txt"])
+        .succeeds()
+        .no_output();
+
+    assert!(at.file_exists("archive.tar.zst"));
+    assert!(!at.read_bytes("archive.tar.zst").is_empty());
+}
+
+#[test]
+fn test_create_zstd_archive_is_readable_by_independent_readers() {
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    at.write("file1.txt", "test content");
+
+    ucmd.args(&["--zstd", "-cf", "archive.tar.zst", "file1.txt"])
+        .succeeds()
+        .no_output();
+
+    let compressed = at.read_bytes("archive.tar.zst");
+    let decoded = zstd::stream::decode_all(Cursor::new(compressed)).unwrap();
+    let mut archive = TarRsArchive::new(Cursor::new(decoded));
+    let mut entries = archive.entries().unwrap();
+    let mut entry = entries.next().unwrap().unwrap();
+
+    assert_eq!(entry.path().unwrap().to_str(), Some("file1.txt"));
+
+    let mut contents = String::new();
+    entry.read_to_string(&mut contents).unwrap();
+    assert_eq!(contents, "test content");
+    assert!(entries.next().is_none());
 }
 
 #[test]
@@ -319,6 +359,125 @@ fn test_extract_multiple_files() {
     assert!(at.file_exists("file2.txt"));
     assert_eq!(at.read("file1.txt"), "content1");
     assert_eq!(at.read("file2.txt"), "content2");
+}
+
+#[test]
+fn test_list_zstd_archive() {
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    at.write("file1.txt", "content1");
+    at.write("file2.txt", "content2");
+
+    ucmd.args(&["--zstd", "-cf", "archive.tar.zst", "file1.txt", "file2.txt"])
+        .succeeds();
+
+    new_ucmd!()
+        .args(&["--zstd", "-tf", "archive.tar.zst"])
+        .current_dir(at.as_string())
+        .succeeds()
+        .stdout_contains("file1.txt")
+        .stdout_contains("file2.txt");
+}
+
+#[test]
+fn test_list_zstd_archive_created_outside_tar() {
+    let at = &at_and_ucmd!().0;
+
+    let mut tar_bytes = Vec::new();
+    {
+        let mut builder = TarRsBuilder::new(&mut tar_bytes);
+        let mut header = TarRsHeader::new_gnu();
+        header.set_mode(0o644);
+        header.set_size("content".len() as u64);
+        header.set_cksum();
+        builder
+            .append_data(&mut header, "external.txt", Cursor::new("content"))
+            .unwrap();
+        builder.finish().unwrap();
+    }
+
+    let compressed = zstd::stream::encode_all(Cursor::new(tar_bytes), 0).unwrap();
+    at.write_bytes("external.tar.zst", &compressed);
+
+    new_ucmd!()
+        .args(&["--zstd", "-tf", "external.tar.zst"])
+        .current_dir(at.as_string())
+        .succeeds()
+        .stdout_contains("external.txt");
+}
+
+#[test]
+fn test_extract_zstd_archive() {
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    at.write("original.txt", "test content");
+    ucmd.args(&["--zstd", "-cf", "archive.tar.zst", "original.txt"])
+        .succeeds();
+
+    at.remove("original.txt");
+
+    new_ucmd!()
+        .args(&["--zstd", "-xf", "archive.tar.zst"])
+        .current_dir(at.as_string())
+        .succeeds()
+        .no_output();
+
+    assert!(at.file_exists("original.txt"));
+    assert_eq!(at.read("original.txt"), "test content");
+}
+
+#[test]
+fn test_list_zstd_archive_without_flag_fails() {
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    at.write("file1.txt", "content1");
+    ucmd.args(&["--zstd", "-cf", "archive.tar.zst", "file1.txt"])
+        .succeeds();
+
+    new_ucmd!()
+        .args(&["-tf", "archive.tar.zst"])
+        .current_dir(at.as_string())
+        .fails()
+        .code_is(2);
+}
+
+#[test]
+fn test_list_invalid_zstd_archive_fails() {
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    at.write("invalid.tar.zst", "definitely not zstd");
+
+    ucmd.args(&["--zstd", "-tf", "invalid.tar.zst"])
+        .fails()
+        .code_is(2);
+}
+
+#[test]
+fn test_list_truncated_zstd_archive_fails() {
+    let at = &at_and_ucmd!().0;
+
+    let mut tar_bytes = Vec::new();
+    {
+        let mut builder = TarRsBuilder::new(&mut tar_bytes);
+        let mut header = TarRsHeader::new_gnu();
+        header.set_mode(0o644);
+        header.set_size("content".len() as u64);
+        header.set_cksum();
+        builder
+            .append_data(&mut header, "truncated.txt", Cursor::new("content"))
+            .unwrap();
+        builder.finish().unwrap();
+    }
+
+    let mut compressed = zstd::stream::encode_all(Cursor::new(tar_bytes), 0).unwrap();
+    compressed.truncate(compressed.len().saturating_sub(2));
+    at.write_bytes("truncated.tar.zst", &compressed);
+
+    new_ucmd!()
+        .args(&["--zstd", "-tf", "truncated.tar.zst"])
+        .current_dir(at.as_string())
+        .fails()
+        .code_is(2);
 }
 
 #[test]


### PR DESCRIPTION
Add an explicit --zstd flag for create, list, and extract so .tar.zst archives work end to end.

Keep the scope narrow by requiring the flag instead of trying to autodetect compression. Add CLI coverage and end-to-end tests for creating, listing, and extracting zstd-compressed archives.