### PR TITLE
tar: fix CI coverage for spawned tar tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,12 +53,12 @@ jobs:
         CODECOV_FLAGS=$( echo "${{ matrix.job.os }}" | sed 's/[^[:alnum:]]/_/g' )
         outputs CODECOV_FLAGS
     - name: Test
-      run: cargo test --no-fail-fast
+      run: cargo test --workspace --no-fail-fast
       env:
         RUSTC_WRAPPER: ""
         RUSTFLAGS: "-Cinstrument-coverage -Zcoverage-options=branch -Ccodegen-units=1 -Copt-level=0 -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
         RUSTDOCFLAGS: "-Cpanic=abort"
-        LLVM_PROFILE_FILE: "tar-%p-%m.profraw"
+        LLVM_PROFILE_FILE: "${{ github.workspace }}/tar-%p-%m.profraw"
         # Use -Z
         RUSTC_BOOTSTRAP: 1
     - name: "`grcov` ~ install"


### PR DESCRIPTION
Make the coverage job include the full workspace and collect coverage from spawned CLI test runs. This prevents exercised tar paths from showing up as uncovered.