### PR TITLE
Bump `ctor` & adapt to change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,11 +337,11 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.12.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8f521dd9c9e5f03986eb5c674b14b21e9ccf2eb9f98fecb681100214d5e9e4f"
+checksum = "f7335955a5f85f95f3188623240e081e7b2059a8ad1bae68944b7cfdd718fb10"
 dependencies = [
- "link-section 0.12.0",
+ "link-section 0.13.1",
  "linktime-proc-macro",
 ]
 
@@ -812,9 +812,9 @@ checksum = "f52437d47b0358721ec869cc7374b2a21f7b2237af9b439c0391341a1fbfbf1b"
 
 [[package]]
 name = "link-section"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0567ec9fe5ffdf9241cd90a7629f250a5f903d6ff4573cf7903308662d6fce40"
+checksum = "ea2c24837c4fd5ab6a31d64133eae954f5199247523cf29586117e85245c0dd3"
 
 [[package]]
 name = "linktime-proc-macro"
@@ -1302,7 +1302,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "clap_mangen",
- "ctor 0.12.0",
+ "ctor 1.0.1",
  "libc",
  "phf",
  "phf_codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,18 +37,18 @@ chrono = { version = "0.4.37", default-features = false, features = [
 clap = { version = "4.4", features = ["wrap_help", "cargo"] }
 clap_complete = "4.5"
 clap_mangen = "0.3"
-ctor = "0.12.0"
+ctor = "1.0.0"
 libc = "0.2.153"
 phf = "0.13.0"
 phf_codegen = "0.13.0"
 rand = { version = "0.10.0" }
 regex = "1.10.4"
-thiserror = "2.0.3"
-uucore = { git = "https://github.com/uutils/coreutils" }
-uutests = { git = "https://github.com/uutils/coreutils" }
 tar = "0.4"
 tempfile = "3.10.1"
 textwrap = { version = "0.16.1", features = ["terminal_size"] }
+thiserror = "2.0.3"
+uucore = { git = "https://github.com/uutils/coreutils" }
+uutests = { git = "https://github.com/uutils/coreutils" }
 xattr = "1.3.1"
 zip = "8.0"
 
@@ -59,8 +59,8 @@ clap_mangen = { workspace = true }
 ctor = { workspace = true }
 phf = { workspace = true }
 textwrap = { workspace = true }
-uutests = { workspace = true }
 uucore = { workspace = true }
+uutests = { workspace = true }
 zip = { workspace = true, optional = true }
 
 tar = { optional = true, version = "0.0.1", package = "uu_tar", path = "src/uu/tar" }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -7,7 +7,7 @@ use std::env;
 pub const TESTS_BINARY: &str = env!("CARGO_BIN_EXE_tarapp");
 
 // Use the ctor attribute to run this function before any tests
-#[ctor::ctor]
+#[ctor::ctor(unsafe)]
 fn init() {
     unsafe {
         // Necessary for uutests to be able to find the binary


### PR DESCRIPTION
This PR bumps `ctor` from `0.12.0` to <del>`0.13.0`</del><del>`1.0.0`</del>`1.0.1` and adapts `tests/tests.rs` to a change in `ctor`. 