### PR TITLE
Make codecov non-blocking

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,11 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    changes:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
Similar to uutils/coreutils, make codecov non-blocking for new patches.  We will enforce this socially instead of mechanically.

Unlike uutils/coreutils, we still want the comment in the comment thread.