### PR TITLE
chore(cargo): remove deprecated package authors field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@
 [package]
 name = "tarapp"
 version = "0.0.1"
-authors = ["uutils developers"]
 license = "MIT"
 description = "tar ~ implemented as universal (cross-platform) utils, written in Rust"
 default-run = "tarapp"

--- a/src/uu/tar/Cargo.toml
+++ b/src/uu/tar/Cargo.toml
@@ -2,7 +2,6 @@
 name = "uu_tar"
 version = "0.0.1"
 edition = "2021"
-authors = ["uutils developers"]
 license = "MIT"
 description = "tar ~ (uutils) an archiving utility"
 


### PR DESCRIPTION
`package.authors` is deprecated: https://github.com/rust-lang/cargo/pull/15068